### PR TITLE
#26: fixed pagination bug

### DIFF
--- a/libs/nestjs-admin/src/utils/pagination.spec.ts
+++ b/libs/nestjs-admin/src/utils/pagination.spec.ts
@@ -16,8 +16,13 @@ describe('Pagination', () => {
     expect(result).toStrictEqual([[1], [3, 4, 5, 6, 7], [10]])
   })
 
-  it('should produce 1 ranges when current=1, pages=1', () => {
+  it('should produce 1 range when current=1, pages=1', () => {
     const result = getPaginationRanges(1, 1, 1)
+    expect(result).toStrictEqual([[1]])
+  })
+
+  it('should produce 1 range when current=1, and totalResults=0', () => {
+    const result = getPaginationRanges(1, 1, 0)
     expect(result).toStrictEqual([[1]])
   })
 })

--- a/libs/nestjs-admin/src/utils/pagination.ts
+++ b/libs/nestjs-admin/src/utils/pagination.ts
@@ -7,7 +7,9 @@ export function getPaginationRanges(
   totalResults: number,
 ) {
   const paddingAroundCurrentPage = 2
-  const pageCount = Math.ceil(totalResults / resultsPerPage)
+
+  // 0 results corresponds to 1 page
+  const pageCount = Math.max(Math.ceil(totalResults / resultsPerPage), 1)
 
   // make sure we don't have an out-of-range page
   currentPage = Math.min(Math.max(1, currentPage), pageCount)


### PR DESCRIPTION
When 0 results show, the pagination element shows

<img width="216" alt="Screenshot 2019-08-23 at 15 03 41" src="https://user-images.githubusercontent.com/23658176/63598326-37f4fc00-c5b7-11e9-950c-d5c2dfd3becc.png">

This has been fixed.